### PR TITLE
chore: update tag for che-nodejs10-ubi image

### DIFF
--- a/kubernetes-manifests/guestbook-app.deployment.yaml
+++ b/kubernetes-manifests/guestbook-app.deployment.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: quay.io/eclipse/che-nodejs10-ubi:nightly
+        image: quay.io/eclipse/che-nodejs10-ubi:next
         command: ['/bin/sh', '-c']
         args: ['cd /home && git clone https://github.com/che-samples/nodejs-mongodb-sample.git && cd nodejs-mongodb-sample/ && npm install && npm start']
         imagePullPolicy: Always


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>
Fix tag of quay.io/eclipse/che-nodejs10-ubi