### PR TITLE
chore: add https protocol for endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -15,6 +15,7 @@ components:
         - exposure: public
           name: nodejs
           targetPort: 8080
+          protocol: https
       memoryLimit: 1G
       mountSources: true
 


### PR DESCRIPTION
chore: add https protocol for endpoint

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-11_10_43](https://github.com/che-samples/nodejs-mongodb-sample/assets/1271546/c4cdbcfc-875e-4655-8939-703dcc2fcdcd)


Related issue: https://issues.redhat.com/browse/CRW-5377