### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: nodejs-mongodb
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-16_06_43](https://github.com/che-samples/nodejs-mongodb-sample/assets/1271546/9c362e66-075b-4ad7-876b-beb8497a8034)

Related issue: https://github.com/eclipse/che/issues/21985

